### PR TITLE
Added @Toggle annotation

### DIFF
--- a/Annotations/Toggle.php
+++ b/Annotations/Toggle.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Qandidate\Bundle\ToggleBundle\Annotations;
+
+/**
+ * @Annotation
+ */
+class Toggle
+{
+    public $name;
+}

--- a/EventListener/ToggleListener.php
+++ b/EventListener/ToggleListener.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Qandidate\Bundle\ToggleBundle\EventListener;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Qandidate\Toggle\ToggleManager;
+use Qandidate\Toggle\Context;
+use Qandidate\Bundle\ToggleBundle\Annotations\Toggle;
+
+class ToggleListener
+{
+    private $reader;
+    private $toggleManager;
+    private $context;
+
+    public function __construct(Reader $reader, ToggleManager $toggleManager, Context $context)
+    {
+        $this->reader           = $reader;
+        $this->toggleManager    = $toggleManager;
+        $this->context          = $context;
+    }
+
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController();
+        $class      = ClassUtils::getClass($controller[0]);
+        $object     = new \ReflectionClass($class);
+        $method     = $object->getMethod($controller[1]);
+
+        foreach ($this->reader->getClassAnnotations($object) as $annotation) {
+            if ($annotation instanceof Toggle) {
+                if (! $this->toggleManager->active($annotation->name, $this->context)) {
+                    throw new NotFoundHttpException();
+                }
+            }
+        }
+
+        foreach ($this->reader->getMethodAnnotations($method) as $annotation) {
+            if ($annotation instanceof Toggle) {
+                if (! $this->toggleManager->active($annotation->name, $this->context)) {
+                    throw new NotFoundHttpException();
+                }
+            }
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,8 @@
         <parameter key="qandidate.toggle.collection.predis.class">Qandidate\Toggle\ToggleCollection\PredisCollection</parameter>
         <parameter key="qandidate.toggle.user_context_factory.class">Qandidate\Bundle\ToggleBundle\Context\UserContextFactory</parameter>
         <parameter key="qandidate.toggle.twig_extension.class">Qandidate\Bundle\ToggleBundle\Twig\ToggleTwigExtension</parameter>
+        <parameter key="qandidate.toggle.toggle.listener.class">Qandidate\Bundle\ToggleBundle\EventListener\ToggleListener</parameter>
+        <parameter key="qandidate.toggle.context.class">Qandidate\Toggle\Context</parameter>
     </parameters>
 
     <services>
@@ -29,5 +31,19 @@
             <argument type="service" id="qandidate.toggle.manager" />
             <argument type="service" id="qandidate.toggle.context_factory" />
         </service>
+
+        <service id="qandidate.toggle.context"
+                 class="%qandidate.toggle.context.class%"
+                 factory-service="qandidate.toggle.context_factory"
+                 factory-method="create">
+        </service>
+
+        <service id="qandidate.toggle.toggle.listener" class="%qandidate.toggle.toggle.listener.class%">
+            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="qandidate.toggle.manager" />
+            <argument type="service" id="qandidate.toggle.context" />
+            <tag name="kernel.event_listener" event="kernel.controller" />
+        </service>
+
     </services>
 </container>

--- a/Tests/DependencyInjection/QandidateToggleExtensionTest.php
+++ b/Tests/DependencyInjection/QandidateToggleExtensionTest.php
@@ -155,5 +155,6 @@ class QandidateToggleExtensionTest extends PHPUnit_Framework_TestCase
     private function mockServiceDependencies()
     {
         $this->containerBuilder->set('security.context', new \stdClass);
+        $this->containerBuilder->set('annotation_reader', new \stdClass);
     }
 }

--- a/Tests/EventListener/Fixture/FooControllerToggleAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerToggleAtClassAndMethod.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Qandidate\Bundle\ToggleBundle\Tests\EventListener\Fixture;
+
+use Qandidate\Bundle\ToggleBundle\Annotations\Toggle;
+
+/**
+ * @Toggle("cool-feature")
+ */
+class FooControllerToggleAtClassAndMethod
+{
+    const METHOD_EXECUTED = 'method.executed';
+
+    /**
+     * @Toggle("another-cool-feature")
+     */
+    public function barAction()
+    {
+        return self::METHOD_EXECUTED;
+    }
+
+    public function bazAction()
+    {
+        return self::METHOD_EXECUTED;
+    }
+}

--- a/Tests/EventListener/ToggleListenerTest.php
+++ b/Tests/EventListener/ToggleListenerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Qandidate\Bundle\ToggleBundle\Tests\EventListener;
+
+use Qandidate\Bundle\ToggleBundle\Annotations\Toggle;
+use Qandidate\Bundle\ToggleBundle\EventListener\ToggleListener;
+use Qandidate\Bundle\ToggleBundle\Tests\EventListener\Fixture\FooControllerToggleAtClassAndMethod;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Qandidate\Toggle\Context;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ToggleListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->request = $this->createRequest();
+    }
+
+    public function tearDown()
+    {
+        $this->listener = null;
+        $this->request = null;
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testInactiveToggleAnnotationAtMethod()
+    {
+        $this->listener = $this->createListener(false);
+        $controller = new FooControllerToggleAtClassAndMethod();
+
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testInactiveToggleAnnotationAtClass()
+    {
+        $this->listener = $this->createListener(false);
+        $controller = new FooControllerToggleAtClassAndMethod();
+
+        $this->event = $this->getFilterControllerEvent(array($controller, 'bazAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+    }
+
+    public function testActiveToggleAnnotationAtMethod()
+    {
+        $this->listener = $this->createListener(true);
+        $controller = new FooControllerToggleAtClassAndMethod();
+
+        $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+        // If we end up here toggle is active, no exception thrown
+        $this->assertTrue(true);
+    }
+
+    protected function createToggleManager($isToggleActive)
+    {
+        $toggleManager = $this->getMockBuilder('Qandidate\Toggle\ToggleManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $toggleManager->method('active')
+            ->willReturn($isToggleActive);
+
+        return $toggleManager;
+    }
+
+    protected function createListener($isToggleActive)
+    {
+        $toggleManager = $this->createToggleManager($isToggleActive);
+
+        return new ToggleListener(new AnnotationReader(), $toggleManager, new Context());
+    }
+
+    protected function createRequest()
+    {
+        return new Request(array(), array(), array());
+    }
+
+    protected function getFilterControllerEvent($controller, Request $request)
+    {
+        $mockKernel = $this->getMockForAbstractClass('Symfony\Component\HttpKernel\Kernel', array('', ''));
+
+        return new FilterControllerEvent($mockKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+    }
+}
+

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -9,4 +9,8 @@
  * file that was distributed with this source code.
  */
 
-require __DIR__ . '/../vendor/autoload.php';
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+$loader = require __DIR__ . '/../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require": {
         "qandidate/toggle": "~0.1",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/framework-bundle": "~2.3",
+        "doctrine/common": "~2.2"
     },
     "require-dev": {
         "symfony/framework-bundle": "~2.3",


### PR DESCRIPTION
Inspired by Symfony's <code>SecurityListener</code> I've created a similar solution for a Toggle annotation.

When the toggle isn't active a 404 exception is thrown.