### PR TITLE
Removed symfony 2.8 deprecation warnings

### DIFF
--- a/Context/UserContextFactory.php
+++ b/Context/UserContextFactory.php
@@ -13,13 +13,13 @@ namespace Qandidate\Bundle\ToggleBundle\Context;
 
 use Qandidate\Toggle\Context;
 use Qandidate\Toggle\ContextFactory;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class UserContextFactory extends ContextFactory
 {
-    public function __construct(SecurityContextInterface $securityContext)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -29,10 +29,10 @@ class UserContextFactory extends ContextFactory
     {
         $context = new Context();
 
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
 
         if (null !== $token) {
-            $context->set('username', $this->securityContext->getToken()->getUsername());
+            $context->set('username', $this->tokenStorage->getToken()->getUsername());
         }
 
         return $context;

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
         </service>
 
         <service id="qandidate.toggle.user_context_factory" class="%qandidate.toggle.user_context_factory.class%">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
         </service>
 
         <service id="qandidate.toggle.twig_extension" class="%qandidate.toggle.twig_extension.class%">
@@ -33,9 +33,8 @@
         </service>
 
         <service id="qandidate.toggle.context"
-                 class="%qandidate.toggle.context.class%"
-                 factory-service="qandidate.toggle.context_factory"
-                 factory-method="createContext">
+                 class="%qandidate.toggle.context.class%">
+            <factory service="qandidate.toggle.context_factory" method="createContext" />
         </service>
 
         <service id="qandidate.toggle.toggle.listener" class="%qandidate.toggle.toggle.listener.class%">

--- a/Tests/Context/UserContextFactoryTest.php
+++ b/Tests/Context/UserContextFactoryTest.php
@@ -12,15 +12,15 @@
 namespace Qandidate\Bundle\ToggleBundle\Context;
 
 use PHPUnit_Framework_TestCase;
-use Qandidate\Bundle\ToggleBundle\Tests\SecurityContext;
+use Qandidate\Bundle\ToggleBundle\Tests\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
 class UserContextFactoryTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->securityContext = new SecurityContext();
-        $this->contextFactory  = new UserContextFactory($this->securityContext);
+        $this->tokenStorage = new TokenStorage();
+        $this->contextFactory  = new UserContextFactory($this->tokenStorage);
     }
 
     /**
@@ -28,7 +28,7 @@ class UserContextFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function it_should_set_the_username_when_available()
     {
-        $this->securityContext->setToken(new AnonymousToken('key', 'foobar'));
+        $this->tokenStorage->setToken(new AnonymousToken('key', 'foobar'));
 
         $this->assertEquals('foobar', $this->contextFactory->createContext()->get('username'));
     }

--- a/Tests/DependencyInjection/QandidateToggleExtensionTest.php
+++ b/Tests/DependencyInjection/QandidateToggleExtensionTest.php
@@ -176,7 +176,7 @@ class QandidateToggleExtensionTest extends PHPUnit_Framework_TestCase
 
     private function mockServiceDependencies()
     {
-        $this->containerBuilder->set('security.context', new \stdClass);
+        $this->containerBuilder->set('security.token_storage', new \stdClass);
         $this->containerBuilder->set('annotation_reader', new \stdClass);
     }
 }

--- a/Tests/Functional/ContextFactoryTest.php
+++ b/Tests/Functional/ContextFactoryTest.php
@@ -20,7 +20,7 @@ class ContextFactoryTest extends WebTestCase
         parent::setUp();
 
         $this->client = static::createClient();
-        $this->client->getContainer()->get('security.context')->setToken($this->createSecurityToken());
+        $this->client->getContainer()->get('security.token_storage')->setToken($this->createSecurityToken());
     }
 
     /**

--- a/Tests/Functional/Resources/config/test_services.xml
+++ b/Tests/Functional/Resources/config/test_services.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="security.context" class="Qandidate\Bundle\ToggleBundle\Tests\SecurityContext" />
+        <service id="security.token_storage" class="Qandidate\Bundle\ToggleBundle\Tests\TokenStorage" />
         <service id="redis_client" class="Predis\Client" />
 
     </services>

--- a/Tests/TokenStorage.php
+++ b/Tests/TokenStorage.php
@@ -11,10 +11,10 @@
 
 namespace Qandidate\Bundle\ToggleBundle\Tests;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
-class SecurityContext implements SecurityContextInterface
+class TokenStorage implements TokenStorageInterface
 {
     private $token;
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/browser-kit": "~2.3",
         "twig/twig": "~1.16,>=1.16.2",
-        "symfony/twig-bundle": "~2.3"
+        "symfony/twig-bundle": "~2.3",
+        "phpunit/phpunit": "5.1.*"
     },
     "suggests": {
         "twig/twig": "For using the twig helper"

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/browser-kit": "~2.3",
         "twig/twig": "~1.16,>=1.16.2",
-        "symfony/twig-bundle": "~2.3",
-        "phpunit/phpunit": "4.3.*"
+        "symfony/twig-bundle": "~2.3"
     },
     "suggests": {
         "twig/twig": "For using the twig helper"


### PR DESCRIPTION
As the bundle produced some deprecation warnings in my 2.8 app I replaced the security.context & factory_method in the service definitions to make it ready for symfony 3.0 (+ regarding refactoring).
(Furthermore I added phpunit to the dev-dependencies to make the test suite more independent from the dev environment...)