### PR TITLE
Add support for symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,16 @@
         }
     },
     "require": {
-        "qandidate/toggle": "~0.1",
-        "symfony/framework-bundle": "^2.7.0",
+        "qandidate/toggle": "~0.1|~1.0",
+        "symfony/framework-bundle": "~2.7|~3.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "symfony/framework-bundle": "^2.7.0",
-        "symfony/browser-kit": "^2.7.0",
+        "symfony/framework-bundle": "~2.7|~3.0",
+        "symfony/browser-kit": "~2.7|~3.0",
         "twig/twig": "~1.16,>=1.16.2",
-        "symfony/twig-bundle": "^2.7.0"
+        "symfony/twig-bundle": "~2.7|~3.0",
+        "phpunit/phpunit": "^4.8"
     },
     "suggest": {
         "twig/twig": "For using the twig helper"


### PR DESCRIPTION
This also includes the fix from https://github.com/qandidate-labs/qandidate-toggle-bundle/pull/26 but still allows `~0.1` so it does not break BC