### PR TITLE
Test against lowest versions of packages with Symfony 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm-nightly
 
 env:
-  - SYMFONY_VERSION="2.7.*"
+  - SYMFONY_VERSION="2.7.*" PREFER_LOWEST='--prefer-lowest'
   - SYMFONY_VERSION="2.8.*"
   - SYMFONY_VERSION="3.0.*"
 
@@ -20,7 +20,7 @@ matrix:
 install:
    - composer self-update
    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update --dev
-   - composer update --prefer-dist --no-interaction
+   - composer update --prefer-dist --no-interaction $PREFER_LOWEST
 
 script:
   - phpunit


### PR DESCRIPTION
dded a change to let travis test against lowest version (with Symfony 2.7 only for now)
