### PR TITLE
Add symfony/security-core dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "qandidate/toggle": "~1.0",
         "symfony/framework-bundle": "~2.7|~3.0",
-        "doctrine/common": "~2.2"
+        "doctrine/common": "~2.2",
+        "symfony/security-core": "~2.7|~3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "~2.7|~3.0",


### PR DESCRIPTION
Because Security dependy has been removed from symfony/framework-bundle
https://github.com/symfony/framework-bundle/commit/f985afaabafb7bc0d5254f8390afe9be7a687047

Fix #41