### PR TITLE
Support invokable controllers in annotation toggle listener

### DIFF
--- a/EventListener/ToggleListener.php
+++ b/EventListener/ToggleListener.php
@@ -26,9 +26,15 @@ class ToggleListener
     public function onKernelController(FilterControllerEvent $event)
     {
         $controller = $event->getController();
-        $class      = ClassUtils::getClass($controller[0]);
-        $object     = new \ReflectionClass($class);
-        $method     = $object->getMethod($controller[1]);
+
+        if (is_array($controller)) {
+            $class      = ClassUtils::getClass($controller[0]);
+            $object     = new \ReflectionClass($class);
+            $method     = $object->getMethod($controller[1]);
+        } else {
+            $object     = new \ReflectionClass($controller);
+            $method     = $object->getMethod('__invoke');
+        }
 
         foreach ($this->reader->getClassAnnotations($object) as $annotation) {
             if ($annotation instanceof Toggle) {

--- a/Tests/EventListener/Fixture/FooControllerToggleAtInvoke.php
+++ b/Tests/EventListener/Fixture/FooControllerToggleAtInvoke.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Qandidate\Bundle\ToggleBundle\Tests\EventListener\Fixture;
+
+use Qandidate\Bundle\ToggleBundle\Annotations\Toggle;
+
+class FooControllerToggleAtInvoke
+{
+    /**
+     * @Toggle("cool-feature-on-invoke")
+     */
+    public function __invoke()
+    {
+        return 'method.executed';
+    }
+}

--- a/Tests/EventListener/ToggleListenerTest.php
+++ b/Tests/EventListener/ToggleListenerTest.php
@@ -7,6 +7,7 @@ use Qandidate\Bundle\ToggleBundle\EventListener\ToggleListener;
 use Qandidate\Bundle\ToggleBundle\Tests\EventListener\Fixture\FooControllerToggleAtClassAndMethod;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Qandidate\Bundle\ToggleBundle\Tests\EventListener\Fixture\FooControllerToggleAtInvoke;
 use Qandidate\Toggle\Context;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -56,6 +57,29 @@ class ToggleListenerTest extends \PHPUnit_Framework_TestCase
         $controller = new FooControllerToggleAtClassAndMethod();
 
         $this->event = $this->getFilterControllerEvent(array($controller, 'barAction'), $this->request);
+        $this->listener->onKernelController($this->event);
+        // If we end up here toggle is active, no exception thrown
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testInactiveToggleAnnotationAtInvoke()
+    {
+        $this->listener = $this->createListener(false);
+        $controller = new FooControllerToggleAtInvoke();
+
+        $this->event = $this->getFilterControllerEvent($controller, $this->request);
+        $this->listener->onKernelController($this->event);
+    }
+
+    public function testActiveToggleAnnotationAtInvoke()
+    {
+        $this->listener = $this->createListener(true);
+        $controller = new FooControllerToggleAtInvoke();
+
+        $this->event = $this->getFilterControllerEvent($controller, $this->request);
         $this->listener->onKernelController($this->event);
         // If we end up here toggle is active, no exception thrown
         $this->assertTrue(true);


### PR DESCRIPTION
Symfony supports invokable controllers. So the `FilterControllerEvent:: getController` can contain an object instead of an array.  This MR adds support for invokable controllers in the (annotation) toggle listener. 