### PR TITLE
Support Symfony 3.3.8 environment variables

### DIFF
--- a/DependencyInjection/QandidateToggleExtension.php
+++ b/DependencyInjection/QandidateToggleExtension.php
@@ -31,6 +31,11 @@ class QandidateToggleExtension extends Extension
 
         $processor = new Processor();
         $config    = $processor->processConfiguration(new Configuration(), $configs);
+
+        if (method_exists($container, 'resolveEnvPlaceholders')) {
+            $config = $container->resolveEnvPlaceholders($config);
+        }
+
         $collection = 'in_memory';
         switch (true) {
             case 'redis' === $config['persistence']:


### PR DESCRIPTION
Symfony 3.3.8 made a change in how it handles environment variables.

Previously (3.3.6) the following configuration worked, but is now broken in 3.3.8.
```
parameters:
    env(FEATURE_1): 'inactive'
    feature_1: '%env(FEATURE_1)%'

qandidate_toggle:
    persistence: config
    toggles:
        feature1:
            name: feature1
            status: '%feature_1%'
```

This adds the `$container->resolveEnvParameters()` method to the loading of the configuration method so that the above will work again with the latest version of Symfony.

ref #47