### PR TITLE
process configuration on the extension

### DIFF
--- a/DependencyInjection/QandidateToggleExtension.php
+++ b/DependencyInjection/QandidateToggleExtension.php
@@ -11,7 +11,6 @@
 
 namespace Qandidate\Bundle\ToggleBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -29,8 +28,7 @@ class QandidateToggleExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/'));
         $loader->load('services.xml');
 
-        $processor = new Processor();
-        $config    = $processor->processConfiguration(new Configuration(), $configs);
+        $config = $this->processConfiguration(new Configuration(), $configs);
         $collection = 'in_memory';
         switch (true) {
             case 'redis' === $config['persistence']:


### PR DESCRIPTION
see https://github.com/symfony/symfony/pull/24021#issuecomment-325654196
This is the preferred way to process configuration. The previous way may become deprecated (https://github.com/symfony/symfony/pull/24021#issuecomment-326002406).

This fixes using environment variables in symfony/dependency-injection 3.3.7 and 3.3.8 (https://github.com/symfony/symfony/issues/24020).

fixes https://github.com/qandidate-labs/qandidate-toggle-bundle/pull/46