### PR TITLE
Avoid deprecation warning when using symfony/config >= 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,9 +21,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('qandidate_toggle');
 
-        $rootNode = $treeBuilder->root('qandidate_toggle');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('qandidate_toggle');
 
         $rootNode
             ->children()


### PR DESCRIPTION
This adds a backwards-compatible change to remove the deprecation notice.

fixes #68