### PR TITLE
Use valid constraints for symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "php": ">=7.2",
         "qandidate/toggle": "^2.0",
         "symfony/framework-bundle": "^4.4||^5.0",
-        "symfony/http-foundation": "^4.4,>=4.4.7||^5.0,>=5.0.7",
-        "symfony/http-kernel": "^4.4,>=4.4.13||^5.0,>=5.1.5",
+        "symfony/http-foundation": "^4.4 >=4.4.7||^5.0 >=5.0.7",
+        "symfony/http-kernel": "^4.4 >=4.4.13||^5.1 >=5.1.5",
         "symfony/security-bundle": "^4.4||^5.0",
         "doctrine/common": "^2.13||^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "php": ">=7.2",
         "qandidate/toggle": "^2.0",
         "symfony/framework-bundle": "^4.4||^5.0",
-        "symfony/http-foundation": "^4.4 >=4.4.7||^5.0 >=5.0.7",
-        "symfony/http-kernel": "^4.4 >=4.4.13||^5.1 >=5.1.5",
+        "symfony/http-foundation": "^4.4||^5.0",
+        "symfony/http-kernel": "^4.4||^5.1",
         "symfony/security-bundle": "^4.4||^5.0",
         "doctrine/common": "^2.13||^3.0"
     },
@@ -42,5 +42,9 @@
     },
     "suggest": {
         "twig/twig": "For using the twig helper"
+    },
+    "conflict": {
+        "symfony/http-foundation": "<4.4.7||>=5.0 <5.0.7",
+        "symfony/http-kernel": "<4.4.13||>=5.0 <5.1.5"
     }
 }


### PR DESCRIPTION
When trying to update this package with composer 2, it chokes on the following error :

```
- qandidate/toggle-bundle is locked to version 1.3.0 and an update of this package was not requested.
    - qandidate/toggle-bundle 1.3.0 requires symfony/http-foundation ^4.4||^5.0,>=5.0.7 -> found symfony/http-foundation[v5.0.7, ..., 5.x-dev] but the package is fixed to v4.4.15 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```

After checking with the online semver checker, it seems that the current constraint (`^x.y, >=x.y.z`) is *not valid*. For the same intent, using the proposed constraint in this PR seems to solve the problem :

- https://jubianchi.github.io/semver-check/#/^4.4%20%3E%3D4.4.7%20||^5.0%20%3E%3D5.0.7/5.0.5 :x: as expected
- https://jubianchi.github.io/semver-check/#/^4.4%20%3E%3D4.4.7%20||^5.0%20%3E%3D5.0.7/5.0.7 :heavy_check_mark:  as expected
- https://jubianchi.github.io/semver-check/#/^4.4%20%3E%3D4.4.7%20||^5.0%20%3E%3D5.0.7/4.4.6 :x: as expected
- https://jubianchi.github.io/semver-check/#/^4.4%20%3E%3D4.4.7%20||^5.0%20%3E%3D5.0.7/4.4.15 :heavy_check_mark:  as expected