### PR TITLE
derekparnell-20220603-add-strategy-yml-config-option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,6 +61,7 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('array')
                                     ->children()
                                         ->scalarNode('name')->end()
+                                        ->scalarNode('strategy')->end()
                                         ->scalarNode('key')->end()
                                         ->arrayNode('operator')
                                             ->prototype('variable')


### PR DESCRIPTION
Added the strategy configuration option to the possible yml configuration settings.

Now we can use the unanimous, and majority strategies, besides the default affirmative strategy, by using YAML configuration.

Example that would require both conditions to be true instead of just one of them, as would be the case with the default affirmative strategy:

```
qandidate_toggle:
    persistence: config
    toggles:
        -   name: unanimous-role-env-toggle
            status: conditionally-active
            strategy: unanimous
            conditions:
                -   name: operator-condition
                    key: env
                    operator:
                        name: in-set
                        values: [dev]
                -   name: operator-condition
                    key: roles
                    operator:
                        name: has-intersection
                        values: [ROLE_SOME_ROLE]
```