### PR TITLE
collect toggles active state at request time

### DIFF
--- a/DataCollector/ToggleCollector.php
+++ b/DataCollector/ToggleCollector.php
@@ -51,7 +51,9 @@ class ToggleCollector extends DataCollector
         $serializer = new ToggleSerializer(new OperatorConditionSerializer(new OperatorSerializer()));
 
         $toggleData = array_map(function (Toggle $toggle) use ($serializer) {
-            return $serializer->serialize($toggle);
+            $result = $serializer->serialize($toggle);
+            $result['active'] = $this->toggleManager->active($toggle->getName(), $this->contextFactory->createContext());
+            return $result;
         }, $this->toggleManager->all());
 
         $this->data['toggleDetails'] = $toggleData;

--- a/Resources/views/data_collector/toggle.html.twig
+++ b/Resources/views/data_collector/toggle.html.twig
@@ -10,7 +10,7 @@
         {% for toggle in collector.toggleDetails %}
             <div class="sf-toolbar-info-piece">
                 <b>{{ toggle.name }}</b>
-                {% if toggle.name is active feature %}
+                {% if toggle.active %}
                     <span class="sf-toolbar-status sf-toolbar-status-green">active</span>
                 {% else %}
                     <span class="sf-toolbar-status sf-toolbar-status-yellow">inactive</span>
@@ -73,7 +73,7 @@
                     <td>{{ toggleDetails.name }}</td>
                     <td>{{ block('toggle_detail_conditions') }}</td>
                     <td>{{ toggleDetails.status }}</td>
-                    {% if toggleDetails.name is active feature %}
+                    {% if toggleDetails.active %}
                         <td><span class="label status-success">active</span></td>
                     {% else %}
                         <td><span class="label status-warning">inactive</span></td>


### PR DESCRIPTION
The active state in the profiler is not correct because the token is no longer available.
this could be due to https://github.com/symfony/symfony/pull/40785
this PR fixes this by recording the active state when we collect toggle datails.